### PR TITLE
Reduce allocations

### DIFF
--- a/NodeReact.Benchmarks/BaseBenchmark.cs
+++ b/NodeReact.Benchmarks/BaseBenchmark.cs
@@ -37,7 +37,7 @@ namespace NodeReact.Benchmarks
 					config.AddScriptWithoutTransform("hugeBundle.js");
 					config.StartEngines = Environment.ProcessorCount;
 					config.MaxEngines = Environment.ProcessorCount;
-                    config.MaxUsagesPerEngine = 300;
+                    config.MaxUsagesPerEngine = int.MaxValue;
 					config.AllowJavaScriptPrecompilation = false;
 				});
 
@@ -69,7 +69,7 @@ namespace NodeReact.Benchmarks
 				.SetAllowJavaScriptPrecompilation(false)
 				.SetStartEngines(Environment.ProcessorCount)
 				.SetMaxEngines(Environment.ProcessorCount)
-				.SetMaxUsagesPerEngine(1000)
+				.SetMaxUsagesPerEngine(int.MaxValue)
 				.SetLoadBabel(false)
                 .SetLoadReact(false)
 				.AddScriptWithoutTransform("hugeBundle.js");

--- a/NodeReact.Benchmarks/BaseBenchmark.cs
+++ b/NodeReact.Benchmarks/BaseBenchmark.cs
@@ -13,7 +13,7 @@ using ZeroReact;
 namespace NodeReact.Benchmarks
 {
 	[MemoryDiagnoser]
-	[InProcess]
+	//[InProcess]
     public abstract class BaseBenchmark
 	{
 		[GlobalSetup]

--- a/NodeReact.Benchmarks/Program.cs
+++ b/NodeReact.Benchmarks/Program.cs
@@ -17,8 +17,8 @@ namespace NodeReact.Benchmarks
             //}
 
 
-            //BenchmarkRunner.Run<SingleComponentBenchmark>();
-            BenchmarkRunner.Run<WebSimulateBenchmark>();
+            BenchmarkRunner.Run<SingleComponentBenchmark>();
+            //BenchmarkRunner.Run<WebSimulateBenchmark>();
             Console.ReadKey();
 		}
 	}

--- a/NodeReact.Benchmarks/Program.cs
+++ b/NodeReact.Benchmarks/Program.cs
@@ -18,7 +18,7 @@ namespace NodeReact.Benchmarks
 
 
             BenchmarkRunner.Run<SingleComponentBenchmark>();
-            //BenchmarkRunner.Run<WebSimulateBenchmark>();
+           // BenchmarkRunner.Run<WebSimulateBenchmark>();
             Console.ReadKey();
 		}
 	}

--- a/NodeReact.Benchmarks/SingleComponentBenchmark.cs
+++ b/NodeReact.Benchmarks/SingleComponentBenchmark.cs
@@ -3,14 +3,12 @@ using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 using NodeReact.Components;
 using React;
-using ZeroReactComponent = ZeroReact.Components.ReactComponent;
-using NodeReactComponent = NodeReact.Components.ReactComponent;
 
 namespace NodeReact.Benchmarks
 {
-	public class SingleComponentBenchmark : BaseBenchmark
-	{
-		private readonly NoTextWriter tk = new NoTextWriter();
+    public class SingleComponentBenchmark : BaseBenchmark
+    {
+        private readonly NoTextWriter tk = new NoTextWriter();
 
         [Benchmark]
         public async Task NodeReact_RenderRouterSingle()
@@ -19,7 +17,7 @@ namespace NodeReact.Benchmarks
             {
                 var reactContext = scope.ServiceProvider.GetRequiredService<NodeReact.IReactScopedContext>();
 
-                var component = reactContext.CreateComponent<ReactRouterComponent>("__desktopComponents.App");
+                var component = reactContext.CreateComponent<NodeReact.Components.ReactRouterComponent>("__desktopComponents.App");
                 component.Props = _testData;
                 component.ServerOnly = true;
                 component.Path = "/movie/246436/";
@@ -37,7 +35,7 @@ namespace NodeReact.Benchmarks
             {
                 var reactContext = scope.ServiceProvider.GetRequiredService<NodeReact.IReactScopedContext>();
 
-                var component = reactContext.CreateComponent<NodeReactComponent>("__components.MovieAboutPage");
+                var component = reactContext.CreateComponent<NodeReact.Components.ReactComponent>("__components.MovieAboutPage");
                 component.Props = _testData;
                 component.ServerOnly = true;
 
@@ -47,14 +45,14 @@ namespace NodeReact.Benchmarks
             }
         }
 
-       // [Benchmark]
+        [Benchmark]
         public async Task ZeroReact_RenderSingle()
         {
             using (var scope = sp.CreateScope())
             {
                 var reactContext = scope.ServiceProvider.GetRequiredService<ZeroReact.IReactScopedContext>();
 
-                var component = reactContext.CreateComponent<ZeroReactComponent>("__components.MovieAboutPage");
+                var component = reactContext.CreateComponent<ZeroReact.Components.ReactComponent>("__components.MovieAboutPage");
                 component.Props = _testData;
                 component.ServerOnly = true;
 
@@ -64,14 +62,32 @@ namespace NodeReact.Benchmarks
             }
         }
 
-      //  [Benchmark]
-	    public void ReactJs_RenderSingle()
-	    {
-		    var environment = AssemblyRegistration.Container.Resolve<IReactEnvironment>();
-		    var component = environment.CreateComponent("__components.MovieAboutPage", _testData, serverOnly: true);
+        [Benchmark]
+        public async Task ZeroReact_RenderRouterSingle()
+        {
+            using (var scope = sp.CreateScope())
+            {
+                var reactContext = scope.ServiceProvider.GetRequiredService<ZeroReact.IReactScopedContext>();
 
-		    component.RenderHtml(tk, renderServerOnly: true);
-		    environment.ReturnEngineToPool();
+                var component = reactContext.CreateComponent<ZeroReact.Components.ReactRouterComponent>("__desktopComponents.App");
+                component.Props = _testData;
+                component.ServerOnly = true;
+                component.Path = "/movie/246436/";
+
+                await component.RenderRouterWithContext();
+
+                component.WriteOutputHtmlTo(tk);
+            }
+        }
+
+        [Benchmark]
+        public void ReactJs_RenderSingle()
+        {
+            var environment = AssemblyRegistration.Container.Resolve<IReactEnvironment>();
+            var component = environment.CreateComponent("__components.MovieAboutPage", _testData, serverOnly: true);
+
+            component.RenderHtml(tk, renderServerOnly: true);
+            environment.ReturnEngineToPool();
         }
     }
 }

--- a/NodeReact.Benchmarks/SingleComponentBenchmark.cs
+++ b/NodeReact.Benchmarks/SingleComponentBenchmark.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
+using NodeReact.Components;
 using React;
 using ZeroReactComponent = ZeroReact.Components.ReactComponent;
 using NodeReactComponent = NodeReact.Components.ReactComponent;
@@ -10,6 +11,24 @@ namespace NodeReact.Benchmarks
 	public class SingleComponentBenchmark : BaseBenchmark
 	{
 		private readonly NoTextWriter tk = new NoTextWriter();
+
+        [Benchmark]
+        public async Task NodeReact_RenderRouterSingle()
+        {
+            using (var scope = sp.CreateScope())
+            {
+                var reactContext = scope.ServiceProvider.GetRequiredService<NodeReact.IReactScopedContext>();
+
+                var component = reactContext.CreateComponent<ReactRouterComponent>("__desktopComponents.App");
+                component.Props = _testData;
+                component.ServerOnly = true;
+                component.Path = "/movie/246436/";
+
+                await component.RenderRouterWithContext();
+
+                component.WriteOutputHtmlTo(tk);
+            }
+        }
 
         [Benchmark]
         public async Task NodeReact_RenderSingle()
@@ -28,7 +47,7 @@ namespace NodeReact.Benchmarks
             }
         }
 
-        [Benchmark]
+       // [Benchmark]
         public async Task ZeroReact_RenderSingle()
         {
             using (var scope = sp.CreateScope())
@@ -45,7 +64,7 @@ namespace NodeReact.Benchmarks
             }
         }
 
-        [Benchmark]
+      //  [Benchmark]
 	    public void ReactJs_RenderSingle()
 	    {
 		    var environment = AssemblyRegistration.Container.Resolve<IReactEnvironment>();

--- a/NodeReact.Sample.Webpack.AspNetCore/Startup.cs
+++ b/NodeReact.Sample.Webpack.AspNetCore/Startup.cs
@@ -22,6 +22,11 @@ namespace NodeReact.Sample.Webpack.AspNetCore
             services.AddNodeReact(
                 config =>
                 {
+                    config.ConfigureOutOfProcessNodeJSServiceOptions = o =>
+                    {
+                        o.NumRetries = 0;
+                        o.TimeoutMS = 2000;
+                    };
                     config.AddScriptWithoutTransform("~/server.bundle.js");
                     config.UseDebugReact = true;
                 });

--- a/NodeReact/Components/ReactBaseComponent.cs
+++ b/NodeReact/Components/ReactBaseComponent.cs
@@ -113,7 +113,7 @@ namespace NodeReact.Components
             WriteSpan(writer, SerializedProps);
         }
 
-        protected string OutputHtml { get; set; }
+        protected IMemoryOwner<char> OutputHtml { get; set; }
         public void WriteOutputHtmlTo(TextWriter writer)
         {
             if (ServerOnly)
@@ -181,6 +181,7 @@ namespace NodeReact.Components
 
         public virtual void Dispose()
         {
+            OutputHtml?.Dispose();
             SerializedProps?.Dispose();
         }
     }

--- a/NodeReact/Components/ReactComponent.cs
+++ b/NodeReact/Components/ReactComponent.cs
@@ -33,7 +33,8 @@ namespace NodeReact.Components
             {
                 try
                 {
-                    OutputHtml = await _nodeInvocationService.Invoke<string>("evalCode", executeEngineCode);
+                    var renderResult = await _nodeInvocationService.Invoke<RenderResult>("evalCode", executeEngineCode);
+                    OutputHtml = renderResult.html;
                 }
                 catch (Exception ex)
                 {
@@ -46,14 +47,25 @@ namespace NodeReact.Components
         {
             using (var writer = new ArrayPooledTextWriter())
             {
+                writer.Write("var context={};");
+                writer.Write("Object.assign(context, {html:");
+
                 writer.Write(ServerOnly ? "ReactDOMServer.renderToStaticMarkup(React.createElement(" : "ReactDOMServer.renderToString(React.createElement(");
                 writer.Write(ComponentName);
                 writer.Write(',');
                 WriterSerialziedProps(writer);
                 writer.Write("))");
 
+                writer.Write("})");
+
                 return writer.GetMemoryOwner();
             }
+        }
+
+        private class RenderResult
+        {
+            public IMemoryOwner<char> html { get; set; }
+
         }
     }
 }

--- a/NodeReact/Components/ReactRouterComponent.cs
+++ b/NodeReact/Components/ReactRouterComponent.cs
@@ -70,7 +70,7 @@ namespace NodeReact.Components
 
     public class RoutingContext
     {
-        public string html { get; set; }
+        internal IMemoryOwner<char> html { get; set; }
 
         /// <summary>
         /// HTTP Status Code.

--- a/NodeReact/Jering.Javascript.NodeJS/CustomSerializerDeserializer.cs
+++ b/NodeReact/Jering.Javascript.NodeJS/CustomSerializerDeserializer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NodeReact.Utils;
+
+namespace NodeReact
+{
+    internal class CustomSerializerDeserializer : JsonConverter<IMemoryOwner<char>>
+    {
+        public override bool CanConvert(Type type)
+        {
+            return typeof(IMemoryOwner<char>).IsAssignableFrom(type);
+        }
+
+        public override IMemoryOwner<char> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            int maxCharsCount = Encoding.UTF8.GetMaxCharCount(reader.ValueSpan.Length);
+
+            var rentedArray = ArrayPool<char>.Shared.Rent(maxCharsCount);
+
+            var length = Encoding.UTF8.GetChars(reader.ValueSpan, rentedArray);
+
+            return new PooledCharBuffer(rentedArray, length);
+        }
+
+        public override void Write(Utf8JsonWriter writer, IMemoryOwner<char> value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.Memory.Span);
+        }
+    }
+}

--- a/NodeReact/Jering.Javascript.NodeJS/HttpNodeJSService.cs
+++ b/NodeReact/Jering.Javascript.NodeJS/HttpNodeJSService.cs
@@ -26,9 +26,11 @@ namespace NodeReact
     {
         private static readonly JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions
         {
-            Converters = { new CustomSerializerDeserializer() },
+            Converters = { new MemoryOwnerJsonConverter() },
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-            DefaultBufferSize = 64536
+            DefaultBufferSize = 64536,
+
+            PropertyNameCaseInsensitive = true
         };
 
         internal const string SERVER_SCRIPT_NAME = "HttpServer.js";
@@ -93,8 +95,8 @@ namespace NodeReact
                     {
                         using (Stream stream = await httpResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
                         {
-                            InvocationError invocationError = await JsonSerializer
-                                .DeserializeAsync<InvocationError>(stream, jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+                            NodeInvocationError invocationError = await JsonSerializer
+                                .DeserializeAsync<NodeInvocationError>(stream, jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
                             throw new InvocationException(invocationError.ErrorMessage, invocationError.ErrorStack);
                         }
                     }

--- a/NodeReact/Jering.Javascript.NodeJS/HttpNodeJSService.cs
+++ b/NodeReact/Jering.Javascript.NodeJS/HttpNodeJSService.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Buffers;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading;
+using System.Threading.Tasks;
+using Jering.IocServices.System.Net.Http;
+using Jering.Javascript.NodeJS;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+using NodeReact.Utils;
+
+namespace NodeReact
+{
+    /// <summary>
+    /// <para>An implementation of <see cref="OutOfProcessNodeJSService"/> that uses Http for inter-process communication.</para>
+    /// <para>The NodeJS child process starts a Http server on an arbitrary port (unless otherwise specified
+    /// using <see cref="NodeJSProcessOptions.Port"/>) and receives invocation requests as Http requests.</para>
+    /// </summary>
+    public class HttpNodeJSService : OutOfProcessNodeJSService
+    {
+        private static readonly JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions
+        {
+            Converters = { new CustomSerializerDeserializer() },
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            DefaultBufferSize = 64536
+        };
+
+        internal const string SERVER_SCRIPT_NAME = "HttpServer.js";
+
+        private readonly IHttpClientService _httpClientService;
+
+        private bool _disposed;
+        internal Uri Endpoint;
+
+        /// <summary>
+        /// Creates a <see cref="HttpNodeJSService"/> instance.
+        /// </summary>
+        /// <param name="outOfProcessNodeJSServiceOptionsAccessor"></param>
+        /// <param name="httpContentFactory"></param>
+        /// <param name="embeddedResourcesService"></param>
+        /// <param name="httpClientService"></param>
+        /// <param name="jsonService"></param>
+        /// <param name="nodeJSProcessFactory"></param>
+        /// <param name="loggerFactory"></param>
+        public HttpNodeJSService(IOptions<OutOfProcessNodeJSServiceOptions> outOfProcessNodeJSServiceOptionsAccessor,
+            IEmbeddedResourcesService embeddedResourcesService,
+            IHttpClientService httpClientService,
+            INodeJSProcessFactory nodeJSProcessFactory,
+            ILoggerFactory loggerFactory) :
+            base(nodeJSProcessFactory,
+                loggerFactory.CreateLogger(typeof(HttpNodeJSService)),
+                outOfProcessNodeJSServiceOptionsAccessor,
+                embeddedResourcesService,
+                typeof(Jering.Javascript.NodeJS.HttpNodeJSService).GetTypeInfo().Assembly,
+                SERVER_SCRIPT_NAME)
+        {
+            
+            _httpClientService = httpClientService;
+        }
+
+        /// <inheritdoc />
+        protected override async Task<(bool, T)> TryInvokeAsync<T>(InvocationRequest invocationRequest, CancellationToken cancellationToken)
+        {
+            using (HttpContent httpContent = new InvocationContent(new NodeInvocationRequest(invocationRequest)))
+            using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, Endpoint))
+            {
+                httpRequestMessage.Content = httpContent;
+
+                // Some notes on disposal:
+                // HttpResponseMessage.Dispose simply calls Dispose on HttpResponseMessage.Content. By default, HttpResponseMessage.Content is a StreamContent instance that has an underlying 
+                // NetworkStream instance that should be disposed. When HttpResponseMessage.Content.ReadAsStreamAsync is called, the NetworkStream is wrapped in a read-only delegating stream
+                // and returned. In most cases below, StreamReader is used to read the read-only stream, upon disposal of the StreamReader, the underlying stream and thus the NetworkStream
+                // are disposed. If HttpStatusCode is NotFound or an exception is thrown, we manually call HttpResponseMessage.Dispose. If we return the stream, we pass on the responsibility 
+                // for disposing it to the caller.
+                HttpResponseMessage httpResponseMessage = null;
+                try
+                {
+                    httpResponseMessage = await _httpClientService.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+
+                    if (httpResponseMessage.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        httpResponseMessage.Dispose();
+                        return (false, default);
+                    }
+
+                    if (httpResponseMessage.StatusCode == HttpStatusCode.InternalServerError)
+                    {
+                        using (Stream stream = await httpResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                        {
+                            InvocationError invocationError = await JsonSerializer
+                                .DeserializeAsync<InvocationError>(stream, jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+                            throw new InvocationException(invocationError.ErrorMessage, invocationError.ErrorStack);
+                        }
+                    }
+
+                    if (httpResponseMessage.StatusCode == HttpStatusCode.OK)
+                    {
+                        if (typeof(T) == typeof(Stream))
+                        {
+                            Stream stream = await httpResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                            return (true, (T)(object)stream);
+                        }
+
+                        if (typeof(T) == typeof(string))
+                        {
+                            string str = await httpResponseMessage.Content.ReadAsStringAsync();
+                            return (true, (T)(object)str);
+                        }
+
+                        using (var contentStream = await httpResponseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                        {
+                            var result = await JsonSerializer
+                                .DeserializeAsync<T>(contentStream, jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+                            return (true, result);
+                        }
+                    }
+                }
+                catch
+                {
+                    httpResponseMessage?.Dispose();
+
+                    throw;
+                }
+
+                throw new InvocationException(string.Format("InvocationException_HttpNodeJSService_UnexpectedStatusCode", httpResponseMessage.StatusCode));
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnConnectionEstablishedMessageReceived(string connectionEstablishedMessage)
+        {
+            // Start after message start and "IP - "
+            int startIndex = CONNECTION_ESTABLISHED_MESSAGE_START.Length + 5;
+            var stringBuilder = new StringBuilder("http://");
+
+            for (int i = startIndex; i < connectionEstablishedMessage.Length; i++)
+            {
+                char currentChar = connectionEstablishedMessage[i];
+
+                if (currentChar == ':')
+                {
+                    // ::1
+                    stringBuilder.Append("[::1]");
+                    i += 2;
+                }
+                else if (currentChar == ' ')
+                {
+                    stringBuilder.Append(':');
+
+                    // Skip over "Port - "
+                    i += 7;
+                }
+                else if (currentChar == ']')
+                {
+                    Endpoint = new Uri(stringBuilder.ToString());
+                    return;
+                }
+                else
+                {
+                    stringBuilder.Append(currentChar);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            base.Dispose(disposing);
+
+            _disposed = true;
+        }
+    }
+}

--- a/NodeReact/Jering.Javascript.NodeJS/InvocationContent.cs
+++ b/NodeReact/Jering.Javascript.NodeJS/InvocationContent.cs
@@ -1,0 +1,86 @@
+﻿using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Jering.Javascript.NodeJS;
+
+namespace NodeReact
+{
+    public class InvocationContent : HttpContent
+    {
+        private static readonly JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions
+        {
+            Converters = { new CustomSerializerDeserializer() },
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            DefaultBufferSize = 64536,
+
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            IgnoreNullValues = true,
+        };
+
+        // Arbitrary boundary
+        internal static readonly byte[] BOUNDARY_BYTES = Encoding.UTF8.GetBytes("--Uiw6+hXl3k+5ia0cUYGhjA==");
+
+        private static readonly MediaTypeHeaderValue _multipartContentType = new MediaTypeHeaderValue("multipart/mixed");
+        private readonly NodeInvocationRequest _invocationRequest;
+
+        /// <summary>
+        /// Creates an <see cref="InvocationContent"/> instance.
+        /// </summary>
+        /// <param name="jsonService">The service for serializing data to JSON.</param>
+        /// <param name="invocationRequest">The invocation request to transmit over Http.</param>
+        public InvocationContent(NodeInvocationRequest invocationRequest)
+        {
+            _invocationRequest = invocationRequest;
+
+            if (invocationRequest.ModuleSourceType == ModuleSourceType.Stream)
+            {
+                Headers.ContentType = _multipartContentType;
+            }
+        }
+
+        /// <summary>
+        /// Serialize the HTTP content to a stream as an asynchronous operation.
+        /// </summary>
+        /// <param name="stream">The target stream.</param>
+        /// <param name="context">Information about the transport (channel binding token, for example). This parameter may be null.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+
+            await JsonSerializer.SerializeAsync(stream, _invocationRequest, jsonSerializerOptions).ConfigureAwait(false);
+
+            // TODO Stream writer allocates both a char[] and a byte[] for buffering, it is slower than just serializing to string and writing the string to the stream
+            // (at least for small-average size payloads). Support for ArrayPool buffers is coming - https://github.com/dotnet/corefx/issues/23874, might need to target
+            // netcoreapp2.1
+            // using (var streamWriter = new StreamWriter(stream, UTF8NoBOM, 256, true))
+            // using (var jsonWriter = new JsonTextWriter(streamWriter))
+            // {
+            //     _jsonService.Serialize(jsonWriter, _invocationRequest);
+            // };
+
+            if (_invocationRequest.ModuleSourceType == ModuleSourceType.Stream)
+            {
+                await stream.WriteAsync(BOUNDARY_BYTES, 0, BOUNDARY_BYTES.Length).ConfigureAwait(false);
+                await _invocationRequest.ModuleStreamSource.CopyToAsync(stream).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the HTTP content has a valid length in bytes.
+        /// </summary>
+        /// <param name="length">The length in bytes of the HTTP content.</param>
+        /// <returns>true if length is a valid length; otherwise, false.</returns>
+        protected override bool TryComputeLength(out long length)
+        {
+            length = -1;
+
+            // Can't determine length
+            return false;
+        }
+    }
+}

--- a/NodeReact/Jering.Javascript.NodeJS/InvocationContent.cs
+++ b/NodeReact/Jering.Javascript.NodeJS/InvocationContent.cs
@@ -14,7 +14,7 @@ namespace NodeReact
     {
         private static readonly JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions
         {
-            Converters = { new CustomSerializerDeserializer() },
+            Converters = { new MemoryOwnerJsonConverter() },
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
             DefaultBufferSize = 64536,
 

--- a/NodeReact/Jering.Javascript.NodeJS/MemoryOwnerJsonConverter.cs
+++ b/NodeReact/Jering.Javascript.NodeJS/MemoryOwnerJsonConverter.cs
@@ -7,7 +7,7 @@ using NodeReact.Utils;
 
 namespace NodeReact
 {
-    internal class CustomSerializerDeserializer : JsonConverter<IMemoryOwner<char>>
+    internal class MemoryOwnerJsonConverter : JsonConverter<IMemoryOwner<char>>
     {
         public override bool CanConvert(Type type)
         {

--- a/NodeReact/Jering.Javascript.NodeJS/NodeInvocationError.cs
+++ b/NodeReact/Jering.Javascript.NodeJS/NodeInvocationError.cs
@@ -1,0 +1,11 @@
+﻿using System.Text.Json.Serialization;
+
+namespace NodeReact
+{
+    public class NodeInvocationError
+    {
+        public string ErrorMessage { get; set; }
+
+        public string ErrorStack { get; set; }
+    }
+}

--- a/NodeReact/Jering.Javascript.NodeJS/NodeInvocationRequest.cs
+++ b/NodeReact/Jering.Javascript.NodeJS/NodeInvocationRequest.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json.Serialization;
+using Jering.Javascript.NodeJS;
+
+namespace NodeReact
+{
+    public class NodeInvocationRequest
+    {
+        public NodeInvocationRequest(InvocationRequest request)
+        {
+            ModuleSource = request.ModuleSource;
+            ModuleSourceType = request.ModuleSourceType;
+            NewCacheIdentifier = request.NewCacheIdentifier;
+            ExportName = request.ExportName;
+            Args = request.Args;
+            ModuleStreamSource = request.ModuleStreamSource;
+        }
+
+        /// <summary>
+        /// Gets the source type of the module to be invoked.
+        /// </summary>
+        public ModuleSourceType ModuleSourceType { get; }
+
+        /// <summary>
+        /// Gets the source of the module to be invoked.
+        /// </summary>
+        public string ModuleSource { get; }
+
+        /// <summary>
+        /// Gets the new cache identifier for the module to be invoked.
+        /// </summary>
+        public string NewCacheIdentifier { get; }
+
+        /// <summary>
+        /// Gets the name of the function in the module's exports to invoke.
+        /// </summary>
+        public string ExportName { get; }
+
+        /// <summary>
+        /// Gets the arguments for the function to invoke.
+        /// </summary>
+        public object[] Args { get; }
+
+        [JsonIgnore]
+        public Stream ModuleStreamSource { get; }
+    }
+}

--- a/NodeReact/NodeInvocationService.cs
+++ b/NodeReact/NodeInvocationService.cs
@@ -62,9 +62,7 @@ namespace NodeReact
 
         public async Task<T> Invoke<T>(string function, IMemoryOwner<char> code, CancellationToken cancellationToken = default)
         {
-            var str = new string(code.Memory.Span);
-
-            var args = new object[] { str };
+            var args = new object[] { code };
 
             // Invoke from cache
             (bool success, T result) = await _nodeJsService.TryInvokeFromCacheAsync<T>(MODULE_CACHE_IDENTIFIER, function, args, cancellationToken);

--- a/NodeReact/NodeReact.csproj
+++ b/NodeReact/NodeReact.csproj
@@ -30,6 +30,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
         <PackageReference Include="Jering.Javascript.NodeJS" Version="4.4.0" />
+        <PackageReference Include="System.Text.Json" Version="4.6.0" />
     </ItemGroup>
 
 </Project>

--- a/NodeReact/ServiceCollectionExtensions.cs
+++ b/NodeReact/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Jering.Javascript.NodeJS;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using NodeReact.Components;
 
 namespace NodeReact
@@ -29,6 +30,11 @@ namespace NodeReact
                 options.EnvironmentVariables.Add("NODEREACT_MAXUSAGESPERFWORKER", config.MaxUsagesPerEngine.ToString());
             });
             services.Configure<OutOfProcessNodeJSServiceOptions>(options => config.ConfigureOutOfProcessNodeJSServiceOptions?.Invoke(options));
+
+            services.Replace(new ServiceDescriptor(
+                typeof(INodeJSService),
+                typeof(HttpNodeJSService), 
+                ServiceLifetime.Singleton));
 
             services.AddScoped<IReactScopedContext, ReactScopedContext>();
 

--- a/NodeReact/Utils/PooledCharBuffer.cs
+++ b/NodeReact/Utils/PooledCharBuffer.cs
@@ -3,7 +3,7 @@ using System.Buffers;
 
 namespace NodeReact.Utils
 {
-    public sealed class PooledCharBuffer : IMemoryOwner<char>
+    internal sealed class PooledCharBuffer : IMemoryOwner<char>
     {
         public PooledCharBuffer(char[] array, int length)
         {


### PR DESCRIPTION
Now used System.Text.Json in HttpNodeJSService and custom converter for IMemoryOwner<char>
**Before**

|                       Method |     Mean |    Error |   StdDev |   Median | Gen 0 | Gen 1 | Gen 2 |  Allocated |
|----------------------------- |---------:|---------:|---------:|---------:|------:|------:|------:|-----------:|
| NodeReact_RenderRouterSingle | 26.34 ms | 0.753 ms | 2.173 ms | 26.17 ms |     - |     - |     - | 2097.53 KB |
|       NodeReact_RenderSingle | 25.63 ms | 0.768 ms | 2.216 ms | 25.37 ms |     - |     - |     - | 1262.37 KB |
|       ZeroReact_RenderSingle | 50.80 ms | 2.594 ms | 7.316 ms | 50.28 ms |     - |     - |     - |    4.73 KB |
| ZeroReact_RenderRouterSingle | 52.67 ms | 1.792 ms | 4.994 ms | 51.27 ms |     - |     - |     - |     7.4 KB |
|         ReactJs_RenderSingle | 54.38 ms | 1.899 ms | 5.599 ms | 54.82 ms |     - |     - |     - | 1305.15 KB |


**After**

|                       Method |     Mean |    Error |   StdDev |   Median | Gen 0 | Gen 1 | Gen 2 |  Allocated |
|----------------------------- |---------:|---------:|---------:|---------:|------:|------:|------:|-----------:|
| NodeReact_RenderRouterSingle | 25.79 ms | 0.847 ms | 2.472 ms | 25.62 ms |     - |     - |     - |   10.09 KB |
|       NodeReact_RenderSingle | 25.91 ms | 0.745 ms | 2.149 ms | 25.63 ms |     - |     - |     - |   10.38 KB |
|       ZeroReact_RenderSingle | 50.92 ms | 2.717 ms | 7.707 ms | 49.87 ms |     - |     - |     - |    4.73 KB |
| ZeroReact_RenderRouterSingle | 53.73 ms | 2.254 ms | 6.393 ms | 51.96 ms |     - |     - |     - |     7.4 KB |
|         ReactJs_RenderSingle | 55.61 ms | 1.890 ms | 5.571 ms | 56.25 ms |     - |     - |     - | 1305.15 KB |

@JeremyTCD