### PR TITLE
Upgraded Microsoft.IO.RecyclableMemoryStream -> 3.0.1. Addded NET 8.0…

### DIFF
--- a/NodeReact.Benchmarks/NodeReact.Benchmarks.csproj
+++ b/NodeReact.Benchmarks/NodeReact.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/NodeReact.Sample.Streaming/NodeReact.Sample.Streaming.csproj
+++ b/NodeReact.Sample.Streaming/NodeReact.Sample.Streaming.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>NodeReact.Sample.Streaming</AssemblyName>
     <RootNamespace>NodeReact.Sample.Streaming</RootNamespace>
   </PropertyGroup>

--- a/NodeReact.Sample/ClientApp/components/index.js
+++ b/NodeReact.Sample/ClientApp/components/index.js
@@ -1,11 +1,11 @@
-import HelloWorld from "./HelloWorld";
-import RootComponent from "./RootComponent";
-import App from "./App";
+import HelloWorld from './HelloWorld';
+import LoremIpsum from './LoremIpsum';
+import RootComponent from './RootComponent';
 
 export const components = {
   HelloWorld,
   RootComponent,
-  App,
+  LoremIpsum
 };
 
 try {

--- a/NodeReact.Sample/NodeReact.Sample.csproj
+++ b/NodeReact.Sample/NodeReact.Sample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NodeReact\NodeReact.csproj" />

--- a/NodeReact/NodeReact.csproj
+++ b/NodeReact/NodeReact.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 
         <Description>Library to render React library components on the server-side with C# as well as on the client.</Description>
         <PackageTags>react, reactjs, nodejs</PackageTags>
@@ -22,7 +22,7 @@
 
         <PackageReference Include="Jering.Javascript.NodeJS" Version="7.0.0-beta.3" />
 
-        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.1" />
+        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 
         <PackageReference Include="Yarn.MSBuild" Version="1.22.19" PrivateAssets="all" ExcludeAssets="Runtime">

--- a/NodeReact/Utils/PooledStream.cs
+++ b/NodeReact/Utils/PooledStream.cs
@@ -15,13 +15,16 @@ internal class PooledStream : IDisposable
         var largeBufferMultiple = 1024 * 1024;
         var maximumBufferSize = 128 * 1024 * 1024;
         
-        _manager = new RecyclableMemoryStreamManager(blockSize, largeBufferMultiple, maximumBufferSize)
+        _manager = new RecyclableMemoryStreamManager(new RecyclableMemoryStreamManager.Options()
         {
+            BlockSize = blockSize,
+            LargeBufferMultiple = largeBufferMultiple,
+            MaximumBufferSize = maximumBufferSize,
             GenerateCallStacks = true,
             AggressiveBufferReturn = true,
-            MaximumFreeLargePoolBytes = largeBufferMultiple * 4,
-            MaximumFreeSmallPoolBytes = 250 * blockSize
-        };
+            MaximumLargePoolFreeBytes = largeBufferMultiple * 4,
+            MaximumSmallPoolFreeBytes = 250 * blockSize
+        });
     }
 
     public PooledStream()


### PR DESCRIPTION
- Upgrade Microsft.IO.RecyclableMemoryStream
  - Breaking chances in the constructor
  - Fixed Pooled Stream with new Options initialisation
- Fixed the Sample project to have the correct extra component added to the index file. Remove App import
- Added NET 8.0 targets to the projects

Modern systems that I'm currently working with, such as Umbraco have dependencies on the new v3 versions of Microsft.IO.RecyclableMemoryStream on their newer versions, this leads to a version conflict that forces me to use the newer v3 versions. These versions have breaking changes on how the Memory Manager is created, fixed in this PR.

Not entirely sure if this is too much change for a single PR + how it should be moved forward since the MS package upgrade is a breaking change. 

Most likely would require the update to be part of a 3.0.0 release of this package into nuget if it was to be merged and released?